### PR TITLE
Fix Italian locale. Incorrect button text.

### DIFF
--- a/it.js
+++ b/it.js
@@ -33,7 +33,7 @@ l10n.translations.it = {
       gphotos: 'Ottieni immagini dal tuo account Google Photos.'
     },
     lineB: 'Bel gioco. Devi fare il login.',
-    button: 'Impossibile connettersi a %source',
+    button: 'Connetti con %source',
     facebookButton: 'Continua con Facebook',
     note: 'Apriremo una nuova pagina per collegare il tuo account %source.',
     cookieWarning: 'Hai bloccato i cookie di terzi nel tuo browser. L’autorizzazione richiede cookie di terzi almeno per il dominio <code>social.uploadcare.com</code>.',


### PR DESCRIPTION
"Impossibile" means "Impossible", which misleads users.
![image](https://user-images.githubusercontent.com/13101080/75680276-4d538d00-5ca2-11ea-861e-db6daeaf2287.png)

